### PR TITLE
#5 - Fix infinite hanging `frontend:dev` Wails command

### DIFF
--- a/frontend/package.tmpl.json
+++ b/frontend/package.tmpl.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build --configuration production --output-hashing none",
+    "build:dev": "ng build --configuration development --delete-output-path false --output-hashing none",
     "watch": "ng build --watch --configuration development --delete-output-path false --output-hashing none",
     "test": "ng test"
   },

--- a/wails.tmpl.json
+++ b/wails.tmpl.json
@@ -3,7 +3,8 @@
   "assetdir": "frontend/dist",
   "frontend:build": "npm run build",
   "frontend:install": "npm install",
-  "frontend:dev": "npm run watch",
+  "frontend:dev": "npm run build:dev",
+  "frontend:dev:watcher": "npm run watch",
   "wailsjsdir": "./frontend",
   "outputfilename": "{{.BinaryName}}",
   "Author": {


### PR DESCRIPTION
Closes #5

- Fix an issue with `frontend:dev` Wails command running an npm command which never exits.

So, the initial closed pipe error appears to be because `npm install` was never run after pulling a fresh instance of the template, so attempting to `ng build` would error out. And this error isn't propagated, hence the cryptic message about the pipe closing.

Running `npm install` fixes the pipe error, however, it then runs into another issue which is that Wails hangs forever while it states it's attempting to install front-end dependencies. It isn't installing dependencies, it's running `npm run watch` which runs `ng build --watch ...`. Because of the `--watch` flag, it hangs forever since this command never exits.

The fix for this was to simply add a new `npm` command called `build:dev` for doing a one-off build identical to the `watch` command except without the `--watch` flag so that it eventually terminates and allows the program to proceed, and assign it to the Wails command `frontend:dev`, then move the `npm run watch` command to the Wails command `frontend:dev:watcher`. After these changes my issues have gone away and things like hot reloading appear to be operating just fine.

I will say though, that it is still important that somehow it be communicated that `npm install` needs to be run to avoid the pipe error on a fresh instance of the template. Though installing dependencies is a pretty standard requirement after pulling a fresh front-end project, perhaps it's not that huge of a deal.